### PR TITLE
Initial loadbalancer module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ commands:
           name: Setup test environment
           command: |
             echo 'export TF_VAR_vault_addr="$(</secrets/VAULT_ADDR)"' >> $BASH_ENV
-            echo 'export TF_VAR_envid="tf_test_lb_${CIRCLE_SHA1}"' >> $BASH_ENV
+            echo 'export TF_VAR_envid="${CIRCLE_SHA1}"' >> $BASH_ENV
 
 jobs:
   integration_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,66 @@
+version: 2.1
+executors:
+  infrastructure_container:
+    docker:
+      - image: aeternity/infrastructure
+    working_directory: /src
+
+commands:
+  integration_tests:
+    description: "Integration Tests"
+    steps:
+      - run:
+          name: Terraform init
+          command: |
+            cd test && envdir /secrets terraform init
+      - run:
+          name: Terraform format check
+          command: |
+            cd test && terraform fmt -check=true -diff=true
+      - run:
+          name: Terraform validate
+          command: |
+            cd test && terraform validate
+      - run:
+          name: Integration environment setup
+          command: |
+            cd test && envdir /secrets terraform apply -parallelism=20 --auto-approve
+      - run:
+          name: Integration environment health check
+          command: |
+            cd test && envdir /secrets ./health-check.sh
+      - run:
+          name: Integration environment cleanup
+          command: |
+            cd test && envdir /secrets terraform destroy -parallelism=20 --auto-approve
+          when: always
+
+  setup_secrets:
+    steps:
+      - run:
+          name: Setup environment secrets
+          command: cd /infrastructure && make secrets SECRETS_OUTPUT_DIR=/secrets
+
+  setup_test_environment:
+    steps:
+      - run:
+          name: Setup test environment
+          command: |
+            echo 'export TF_VAR_vault_addr="$(</secrets/VAULT_ADDR)"' >> $BASH_ENV
+            echo 'export TF_VAR_envid="tf_test_lb_${CIRCLE_SHA1}"' >> $BASH_ENV
+
+jobs:
+  integration_tests:
+    executor: infrastructure_container
+    steps:
+      - checkout
+      - setup_secrets
+      - setup_test_environment
+      - integration_tests
+
+workflows:
+  test:
+    jobs:
+      - integration_tests:
+          context: ae-infra-manage
+          requires: []

--- a/dns.tf
+++ b/dns.tf
@@ -1,0 +1,30 @@
+data "aws_region" "current" {}
+
+resource "aws_route53_health_check" "lb" {
+  fqdn              = "${aws_lb.api.dns_name}"
+  port              = 80
+  type              = "HTTP"
+  resource_path     = "/healthz"
+  measure_latency   = false
+  failure_threshold = "4"
+  request_interval  = 30
+}
+
+resource "aws_route53_record" "lb" {
+  zone_id = "${var.dns_zone}"
+  name    = "${var.fqdn}"
+  type    = "A"
+
+  health_check_id = "${aws_route53_health_check.lb.id}"
+  set_identifier  = "${var.fqdn}-${data.aws_region.current.name}"
+
+  alias {
+    name                   = "${aws_lb.api.dns_name}"
+    zone_id                = "${aws_lb.api.zone_id}"
+    evaluate_target_health = true
+  }
+
+  latency_routing_policy {
+    region = "${data.aws_region.current.name}"
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,136 @@
+resource "aws_lb" "api" {
+  name_prefix        = "apilb-"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.lb.id]
+  subnets            = var.subnets
+
+  enable_deletion_protection = false
+}
+
+resource "aws_lb_target_group" "api_health_check" {
+  name_prefix = "hlt-"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    path                = "/healthz"
+    port                = 8080
+    interval            = 30
+  }
+}
+
+resource "aws_lb_target_group" "external_api" {
+  name_prefix = "ext-"
+  port        = 3013
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    path                = "/healthz"
+    port                = 8080
+    interval            = 30
+  }
+}
+
+resource "aws_lb_target_group" "internal_api" {
+  count       = var.internal_api_enabled ? 1 : 0
+  name_prefix = "int-"
+  port        = 3113
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    path                = "/healthz"
+    port                = 8080
+    interval            = 30
+  }
+}
+
+resource "aws_lb_target_group" "state_channels_api" {
+  count       = var.state_channel_api_enabled ? 1 : 0
+  name_prefix = "sc-"
+  port        = 3014
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+
+  health_check {
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 3
+    path                = "/healthz"
+    port                = 8080
+    interval            = 30
+  }
+
+  stickiness {
+    enabled         = true
+    type            = "lb_cookie"
+    cookie_duration = 86400
+  }
+}
+
+resource "aws_alb_listener" "api" {
+  load_balancer_arn = aws_lb.api.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.external_api.arn
+  }
+}
+
+resource "aws_lb_listener_rule" "health_check" {
+  listener_arn = "${aws_alb_listener.api.arn}"
+
+  condition {
+    field  = "path-pattern"
+    values = ["/healthz"]
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.api_health_check.arn}"
+  }
+}
+
+resource "aws_lb_listener_rule" "dry-run" {
+  count        = var.internal_api_enabled ? 1 : 0
+  listener_arn = "${aws_alb_listener.api.arn}"
+
+  condition {
+    field  = "path-pattern"
+    values = ["/v2/debug/transactions/dry-run"]
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.internal_api.0.arn}"
+  }
+}
+
+resource "aws_lb_listener_rule" "state_channels_api" {
+  count        = var.state_channel_api_enabled ? 1 : 0
+  listener_arn = "${aws_alb_listener.api.arn}"
+
+  condition {
+    field  = "path-pattern"
+    values = ["/channel"]
+  }
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.state_channels_api.0.arn}"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,12 @@
+output "fqdn" {
+  value = "${aws_route53_record.lb.name}"
+}
+
+output target_groups {
+  value = concat(
+    list(aws_lb_target_group.api_health_check.arn),
+    list(aws_lb_target_group.external_api.arn),
+    aws_lb_target_group.internal_api.*.arn,
+    aws_lb_target_group.state_channels_api.*.arn
+  )
+}

--- a/security.tf
+++ b/security.tf
@@ -1,0 +1,53 @@
+resource "aws_security_group" "lb" {
+  name_prefix = "ae-api-lb-"
+  vpc_id      = "${var.vpc_id}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "all_out" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.lb.id}"
+}
+
+resource "aws_security_group_rule" "http_in" {
+  type              = "ingress"
+  from_port         = 80
+  to_port           = 80
+  protocol          = "TCP"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = "${aws_security_group.lb.id}"
+}
+
+resource "aws_security_group_rule" "local_external_api_in" {
+  type                     = "ingress"
+  from_port                = 3013
+  to_port                  = 3013
+  protocol                 = "TCP"
+  security_group_id        = "${var.security_group}"
+  source_security_group_id = "${aws_security_group.lb.id}"
+}
+
+resource "aws_security_group_rule" "local_internal_api_in" {
+  type                     = "ingress"
+  from_port                = 3113
+  to_port                  = 3113
+  protocol                 = "TCP"
+  security_group_id        = "${var.security_group}"
+  source_security_group_id = "${aws_security_group.lb.id}"
+}
+
+resource "aws_security_group_rule" "local_state_channels_api_in" {
+  type                     = "ingress"
+  from_port                = 3014
+  to_port                  = 3014
+  protocol                 = "TCP"
+  security_group_id        = "${var.security_group}"
+  source_security_group_id = "${aws_security_group.lb.id}"
+}

--- a/test/aws.tf
+++ b/test/aws.tf
@@ -1,0 +1,11 @@
+# Default
+provider "aws" {
+  version = "2.16.0"
+  region  = "us-east-1"
+}
+
+provider "aws" {
+  version = "2.16.0"
+  region  = "ap-southeast-2"
+  alias   = "ap-southeast-2"
+}

--- a/test/health-check.sh
+++ b/test/health-check.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+API_ADDR=$(terraform output -json |jq -r '."fqdn"."value"')
+
+# Basic health check endpoint
+curl -sSf -o /dev/null --retry 10 --retry-connrefused http://${API_ADDR}/healthz
+
+# External API
+curl -sSf -o /dev/null --retry 10 --retry-connrefused http://${API_ADDR}/v2/status
+
+# Internal API (dry-run)
+EXT_STATUS=$(curl -sS -o /dev/null --retry 10 --retry-connrefused \
+    -X POST -H 'Content-type: application/json' -d '{}' \
+    -w "%{http_code}" \
+    http://${API_ADDR}/v2/debug/transactions/dry-run)
+[ $EXT_STATUS -eq 400 ]
+
+# State Channels WebSocket API
+WS_STATUS=$(curl -sS -o /dev/null --retry 10 --retry-connrefused \
+    -w "%{http_code}" \
+    http://${API_ADDR}/channel)
+[ $WS_STATUS -eq 426 ]

--- a/test/outputs.tf
+++ b/test/outputs.tf
@@ -1,0 +1,7 @@
+output "fqdn" {
+  value = "${module.test_gateway_lb.fqdn}"
+}
+
+output "target_groups" {
+  value = "${module.test_gateway_lb.target_groups}"
+}

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,0 +1,49 @@
+locals {
+  fqdn = format("%s%s", substr(var.envid, 0, 15), var.domain_sfx)
+}
+
+# TODO - change module source once it is merged to master
+module "test_nodes_sydney" {
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=refactor"
+  env               = "test"
+  envid             = "${var.envid}"
+  bootstrap_version = "${var.bootstrap_version}"
+  vault_role        = "ae-node"
+  vault_addr        = "${var.vault_addr}"
+
+  static_nodes   = 0
+  spot_nodes_min = 1
+  spot_nodes_max = 2
+
+  spot_price    = "0.15"
+  instance_type = "t3.large"
+  ami_name      = "aeternity-ubuntu-16.04-*"
+
+  additional_storage      = true
+  additional_storage_size = 5
+
+  asg_target_groups = module.test_gateway_lb.target_groups
+
+  aeternity = {
+    package = "${var.package}"
+  }
+
+  providers = {
+    aws = "aws.ap-southeast-2"
+  }
+}
+
+module "test_gateway_lb" {
+  source                    = "../"
+  internal_api_enabled      = true
+  state_channel_api_enabled = true
+  dns_zone                  = var.dns_zone
+  fqdn                      = local.fqdn
+  security_group            = module.test_nodes_sydney.sg_id
+  vpc_id                    = module.test_nodes_sydney.vpc_id
+  subnets                   = module.test_nodes_sydney.subnets
+
+  providers = {
+    aws = "aws.ap-southeast-2"
+  }
+}

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,5 +1,5 @@
 locals {
-  fqdn = format("%s%s", substr(var.envid, 0, 15), var.domain_sfx)
+  fqdn = format("lb%s%s", var.envid, var.domain_sfx)
 }
 
 # TODO - change module source once it is merged to master

--- a/test/test.tf
+++ b/test/test.tf
@@ -2,9 +2,8 @@ locals {
   fqdn = format("lb%s%s", var.envid, var.domain_sfx)
 }
 
-# TODO - change module source once it is merged to master
 module "test_nodes_sydney" {
-  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=refactor"
+  source            = "github.com/aeternity/terraform-aws-aenode-deploy?ref=master"
   env               = "test"
   envid             = "${var.envid}"
   bootstrap_version = "${var.bootstrap_version}"

--- a/test/variables.tf
+++ b/test/variables.tf
@@ -1,0 +1,23 @@
+variable "dns_zone" {
+  default = "Z2J3KVPABDNIL1"
+}
+
+variable "domain_sfx" {
+  default = ".ops.aeternity.com"
+}
+
+variable "envid" {
+  description = "Unique test environment identifier to prevent collisions."
+}
+
+variable "vault_addr" {
+  description = "Vault server URL address"
+}
+
+variable "bootstrap_version" {
+  default = "master"
+}
+
+variable "package" {
+  default = "https://s3.eu-central-1.amazonaws.com/aeternity-node-builds/aeternity-latest-ubuntu-x86_64.tar.gz"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,9 +21,11 @@ variable "dns_zone" {
 variable "internal_api_enabled" {
   description = "Enable internal API listener and allow traffic in security group"
   type        = bool
+  default     = false
 }
 
 variable "state_channel_api_enabled" {
   description = "Enable state channels websockets API listener and allow traffic in security group"
   type        = bool
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,29 @@
+variable "vpc_id" {
+  description = "VPC of the nodes fleet"
+}
+
+variable "subnets" {
+  description = "Subnets of the nodes fleet"
+}
+
+variable "security_group" {
+  description = "Security group to allow load balancer traffic to"
+}
+
+variable "fqdn" {
+  description = "Fully qualified domain name of the load balancer. Used for latency routing."
+}
+
+variable "dns_zone" {
+  description = "DNS zone (AWS) of the FQDN domain"
+}
+
+variable "internal_api_enabled" {
+  description = "Enable internal API listener and allow traffic in security group"
+  type        = bool
+}
+
+variable "state_channel_api_enabled" {
+  description = "Enable state channels websockets API listener and allow traffic in security group"
+  type        = bool
+}


### PR DESCRIPTION
Supports:
- external API
- internal API (try-run only)
- state channels web-sockets API (+stickiness)

A bit different URL model than the old gateway, URL based routing in the load balancer instead of using different ports/services/listeners.

TODO:
- [x] update the reference to the aenode terraform module