### PR TITLE
Config tune

### DIFF
--- a/dns.tf
+++ b/dns.tf
@@ -8,6 +8,10 @@ resource "aws_route53_health_check" "lb" {
   measure_latency   = false
   failure_threshold = "4"
   request_interval  = 30
+
+  tags = {
+    env = "${var.env}"
+  }
 }
 
 resource "aws_route53_record" "lb" {

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,10 @@ resource "aws_lb" "api" {
   subnets            = var.subnets
 
   enable_deletion_protection = false
+
+  tags = {
+    env = "${var.env}"
+  }
 }
 
 resource "aws_lb_target_group" "api_health_check" {
@@ -21,6 +25,10 @@ resource "aws_lb_target_group" "api_health_check" {
     path                = "/healthz"
     port                = 8080
     interval            = 30
+  }
+
+  tags = {
+    env = "${var.env}"
   }
 }
 
@@ -43,6 +51,10 @@ resource "aws_lb_target_group" "external_api" {
     enabled         = true
     type            = "lb_cookie"
     cookie_duration = 86400
+  }
+
+  tags = {
+    env = "${var.env}"
   }
 }
 
@@ -67,6 +79,10 @@ resource "aws_lb_target_group" "internal_api" {
     type            = "lb_cookie"
     cookie_duration = 86400
   }
+
+  tags = {
+    env = "${var.env}"
+  }
 }
 
 resource "aws_lb_target_group" "state_channels_api" {
@@ -89,6 +105,10 @@ resource "aws_lb_target_group" "state_channels_api" {
     enabled         = true
     type            = "lb_cookie"
     cookie_duration = 86400
+  }
+
+  tags = {
+    env = "${var.env}"
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,12 @@ resource "aws_lb_target_group" "external_api" {
     port                = 8080
     interval            = 30
   }
+
+  stickiness {
+    enabled         = true
+    type            = "lb_cookie"
+    cookie_duration = 86400
+  }
 }
 
 resource "aws_lb_target_group" "internal_api" {
@@ -54,6 +60,12 @@ resource "aws_lb_target_group" "internal_api" {
     path                = "/healthz"
     port                = 8080
     interval            = 30
+  }
+
+  stickiness {
+    enabled         = true
+    type            = "lb_cookie"
+    cookie_duration = 86400
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -105,13 +105,13 @@ resource "aws_lb_listener_rule" "health_check" {
   }
 }
 
-resource "aws_lb_listener_rule" "dry-run" {
+resource "aws_lb_listener_rule" "internal_api" {
   count        = var.internal_api_enabled ? 1 : 0
   listener_arn = "${aws_alb_listener.api.arn}"
 
   condition {
     field  = "path-pattern"
-    values = ["/v2/debug/transactions/dry-run"]
+    values = ["/v2/debug/*"]
   }
 
   action {

--- a/test/health-check.sh
+++ b/test/health-check.sh
@@ -10,6 +10,12 @@ curl -sSf -o /dev/null --retry 10 --retry-connrefused http://${API_ADDR}/healthz
 # External API
 curl -sSf -o /dev/null --retry 10 --retry-connrefused http://${API_ADDR}/v2/status
 
+# Internal API (peers)
+curl -sSf -o /dev/null --retry 10 --retry-connrefused http://${API_ADDR}/v2/debug/peers
+
+# Internal API (pending transactions)
+curl -sSf -o /dev/null --retry 10 --retry-connrefused http://${API_ADDR}/v2/debug/transactions/pending
+
 # Internal API (dry-run)
 EXT_STATUS=$(curl -sS -o /dev/null --retry 10 --retry-connrefused \
     -X POST -H 'Content-type: application/json' -d '{}' \

--- a/test/test.tf
+++ b/test/test.tf
@@ -34,6 +34,7 @@ module "test_nodes_sydney" {
 
 module "test_gateway_lb" {
   source                    = "../"
+  env                       = "test"
   internal_api_enabled      = true
   state_channel_api_enabled = true
   dns_zone                  = var.dns_zone

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,9 @@ variable "state_channel_api_enabled" {
   type        = bool
   default     = false
 }
+
+variable "env" {
+  description = "Used for tagging purposes only, thus the default for BC"
+  type        = string
+  default     = "unknown"
+}


### PR DESCRIPTION
- enable sticky sessions for external & internal APIs
- add env tag to some resources for tracking/information purposes
- enable all debug endpoints of internal API