### PR TITLE
Disable LB sticky sessions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,12 +47,6 @@ resource "aws_lb_target_group" "external_api" {
     interval            = 30
   }
 
-  stickiness {
-    enabled         = true
-    type            = "lb_cookie"
-    cookie_duration = 86400
-  }
-
   tags = {
     env = "${var.env}"
   }
@@ -74,12 +68,6 @@ resource "aws_lb_target_group" "internal_api" {
     interval            = 30
   }
 
-  stickiness {
-    enabled         = true
-    type            = "lb_cookie"
-    cookie_duration = 86400
-  }
-
   tags = {
     env = "${var.env}"
   }
@@ -99,12 +87,6 @@ resource "aws_lb_target_group" "state_channels_api" {
     path                = "/healthz"
     port                = 8080
     interval            = 30
-  }
-
-  stickiness {
-    enabled         = true
-    type            = "lb_cookie"
-    cookie_duration = 86400
   }
 
   tags = {

--- a/test/health-check.sh
+++ b/test/health-check.sh
@@ -23,8 +23,9 @@ EXT_STATUS=$(curl -sS -o /dev/null --retry 10 --retry-connrefused \
     http://${API_ADDR}/v2/debug/transactions/dry-run)
 [ $EXT_STATUS -eq 400 ]
 
+# Temporary disabled - https://github.com/aeternity/aeternity/issues/3131
 # State Channels WebSocket API
-WS_STATUS=$(curl -sS -o /dev/null --retry 10 --retry-connrefused \
-    -w "%{http_code}" \
-    http://${API_ADDR}/channel)
-[ $WS_STATUS -eq 426 ]
+# WS_STATUS=$(curl -sS -o /dev/null --retry 10 --retry-connrefused \
+#     -w "%{http_code}" \
+#     http://${API_ADDR}/channel)
+# [ $WS_STATUS -eq 426 ]


### PR DESCRIPTION
ALB Cookie based sticky sessions are not very useful and even harmful for CDN edge caches
As this is distributed system with eventual consistency anyway, clients should plan for it